### PR TITLE
Schedule Integration

### DIFF
--- a/data/techSchedule.json
+++ b/data/techSchedule.json
@@ -1,0 +1,48 @@
+{
+    "Technicians": [
+        {
+            "Name": "Alex Bryan",
+            "Assignment": "SysEn",
+            "Schedule": {
+                "Monday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Tuesday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Wednesday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Thursday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Friday": "8:00AM - 12:00PM,1:00PM - 5:00PM"
+            }
+        },
+        {
+            "Name": "Collin Davis",
+            "Assignment": "Zone 2",
+            "Schedule": {
+                "Monday": "9:00AM - 4:30PM",
+                "Tuesday": "9:00AM - 4:30PM",
+                "Wednesday": "9:00AM - 4:30PM",
+                "Thursday": "9:00AM - 4:30PM",
+                "Friday": "9:00AM - 4:30PM"
+            }
+        },
+        {
+            "Name": "Colton Hopster",
+            "Assignment": "Zone 1",
+            "Schedule": {
+                "Monday": "NA",
+                "Tuesday": "9:30AM - 5:00PM",
+                "Wednesday": "9:30AM - 5:00PM",
+                "Thursday": "8:00AM - 12:00PM",
+                "Friday": "NA"
+            }
+        },
+        {
+            "Name": "Jason Vanlandingham",
+            "Assignment": "Zone 4",
+            "Schedule": {
+                "Monday": "9:30AM - 5:00PM",
+                "Tuesday": "9:30AM - 5:00PM",
+                "Wednesday": "9:30AM - 5:00PM",
+                "Thursday": "9:30AM - 5:00PM",
+                "Friday": "9:30AM - 5:00PM"
+            }
+        }
+    ]
+}

--- a/data/techSchedule.json
+++ b/data/techSchedule.json
@@ -12,25 +12,58 @@
             }
         },
         {
+            "Name": "Cian Melker",
+            "Assignment": "Networking",
+            "Schedule": {
+                "Monday": "8:00AM - 3:30PM",
+                "Tuesday": "8:00AM - 3:30PM",
+                "Wednesday": "8:00AM - 3:30PM",
+                "Thursday": "8:00AM - 3:30PM",
+                "Friday": "8:00AM - 3:30PM"
+            }
+        },
+        {
             "Name": "Collin Davis",
             "Assignment": "Zone 2",
             "Schedule": {
-                "Monday": "9:00AM - 4:30PM",
-                "Tuesday": "9:00AM - 4:30PM",
-                "Wednesday": "9:00AM - 4:30PM",
-                "Thursday": "9:00AM - 4:30PM",
-                "Friday": "9:00AM - 4:30PM"
+                "Monday": "NA",
+                "Tuesday": "8:00AM - 3:30PM",
+                "Wednesday": "8:00AM - 5:00PM",
+                "Thursday": "8:00AM - 12:00PM",
+                "Friday": "8:00AM - 5:00PM"
             }
         },
         {
             "Name": "Colton Hopster",
             "Assignment": "Zone 1",
             "Schedule": {
-                "Monday": "NA",
+                "Monday": "11:00AM - 5:00PM",
                 "Tuesday": "9:30AM - 5:00PM",
                 "Wednesday": "9:30AM - 5:00PM",
-                "Thursday": "8:00AM - 12:00PM",
+                "Thursday": "9:30AM - 5:00PM",
                 "Friday": "NA"
+            }
+        },
+        {
+            "Name": "Jack Nyman",
+            "Assignment": "Coding",
+            "Schedule": {
+                "Monday": "9:00AM - 5:00PM",
+                "Tuesday": "9:00AM - 5:00PM",
+                "Wednesday": "9:00AM - 5:00PM",
+                "Thursday": "9:00AM - 5:00PM",
+                "Friday": "9:00AM - 5:00PM"
+            }
+        },
+        {
+            "Name": "Jarred Heddins",
+            "Assignment": "Zone 1",
+            "Schedule": {
+                "Monday": "11:00AM - 5:00PM",
+                "Tuesday": "11:00AM - 5:00PM",
+                "Wednesday": "11:00AM - 5:00PM",
+                "Thursday": "11:00AM - 5:00PM",
+                "Friday": "11:00AM - 5:00PM"
             }
         },
         {
@@ -42,6 +75,72 @@
                 "Wednesday": "9:30AM - 5:00PM",
                 "Thursday": "9:30AM - 5:00PM",
                 "Friday": "9:30AM - 5:00PM"
+            }
+        },
+        {
+            "Name": "Korrin Sutherburg",
+            "Assignment": "Zone 3",
+            "Schedule": {
+                "Monday": "8:00AM - 10:00AM,1:00PM - 5:00PM",
+                "Tuesday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Wednesday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Thursday": "8:00AM - 12:00PM,1:00PM - 5:00PM",
+                "Friday": "8:00AM - 12:00PM,1:00PM - 5:00PM"
+            }
+        },
+        {
+            "Name": "Lexus Fermelia",
+            "Assignment": "Zone 2",
+            "Schedule": {
+                "Monday": "11:00AM - 5:00PM",
+                "Tuesday": "1:00PM - 5:00PM",
+                "Wednesday": "NA",
+                "Thursday": "10:00AM - 1:00PM,2:00PM-5:00PM",
+                "Friday": "NA"
+            }
+        },
+        {
+            "Name": "Mario Garcia-Ceballos",
+            "Assignment": "Zone 3",
+            "Schedule": {
+                "Monday": "9:00AM - 12:00PM,2:00PM - 5:00PM",
+                "Tuesday": "9:00AM - 12:00PM,2:00PM - 5:00PM",
+                "Wednesday": "9:00AM - 12:00PM,2:00PM - 5:00PM",
+                "Thursday": "9:00AM - 12:00PM,2:00PM - 5:00PM",
+                "Friday": "9:00AM - 12:00PM,2:00PM - 5:00PM"
+            }
+        },
+        {
+            "Name": "Michael Stoll",
+            "Assignment": "Zone 2",
+            "Schedule": {
+                "Monday": "NA",
+                "Tuesday": "NA",
+                "Wednesday": "12:00PM - 5:00PM",
+                "Thursday": "12:00PM - 5:00PM",
+                "Friday": "12:00PM - 5:00PM"
+            }
+        },
+        {
+            "Name": "Sofia Newsome",
+            "Assignment": "Zone 4",
+            "Schedule": {
+                "Monday": "12:00PM - 4:00PM",
+                "Tuesday": "12:00PM - 4:00PM",
+                "Wednesday": "12:00PM - 4:00PM",
+                "Thursday": "12:00PM - 4:00PM",
+                "Friday": "NA"
+            }
+        },
+        {
+            "Name": "Thomas Lockwood",
+            "Assignment": "Zone 1",
+            "Schedule": {
+                "Monday": "NA",
+                "Tuesday": "8:00AM - 3:30PM",
+                "Wednesday": "NA",
+                "Thursday": "NA",
+                "Friday": "NA"
             }
         }
     ]

--- a/html-css-js/admin_tools.js
+++ b/html-css-js/admin_tools.js
@@ -150,10 +150,16 @@ function setScheduleEditor() {
     let buttonFieldset = document.createElement('div');
     buttonFieldset.classList.add("schdEditorButtonsDiv");
     buttonFieldset.innerHTML = `
-    <fieldset>
-        <legend> Buttons </legend>
-        <button> Set Schedule </button>
-        <button> Add Technician </button>
+    <fieldset className="techSchdOptions">
+        <legend> Options </legend>
+        <button onclick="updateAllTechSchedules()"> Save All Schedules </button>
+        <button onclick="addBlankTechSchedule()"> Add a Technician </button>
+        <button onclick="setRemoveMode()"> Remove a Technician </button>
+        <button onclick="exportSchd()"> Export Schedules </button>
+        <div class="techFilterDiv">
+            <label for="techSchdFilter">Filter Technician:</label>
+            <textarea id="techSchdFilter" placeholder="Name:" onkeyup="filterTechs()"></textarea>
+        </div>
     </fieldset>`;
     schedule_editor.appendChild(buttonFieldset);
     // Make filters (?)
@@ -165,12 +171,63 @@ function setScheduleEditor() {
     // replace admin_internals
     let admin_internals = document.getElementById('admin_internals');
     admin_internals.replaceWith(schedule_editor);
+    // Add additional Listeners
+    document.getElementById('techSchdFilter').addEventListener('keydown', function(event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+        } 
+    });
+    // update hours for everyone
+    for(tech in scheduleData.Technicians) {
+        let techObj = scheduleData.Technicians[tech];
+        updateHours(`tech${techObj.Name}`,`${techObj.Name.split(" ")[1]}Hours`);
+    }
     return;
 }
 
-// TODO - return a div for each tech given
+// TODO: set remove mode,
+//  I really dont want to accidentally remove someone with a misclick
+//   so I want this to be a popup with a list of techs. With a button
+function setRemoveMode() {
+    return;
+}
+
+// TODO: place a blank tech table at the top of the page.
+//s empty name, unassigned, no time selected on the table.
+// The save button here will need to be a little different
+//  it will need to add the new tech to the array of objects.
+//  the other function updates an existing entry.
+function addBlankTechSchedules() {
+    return;
+}
+
+// TODO: Export Schdule
+function exportSchd() {
+    return;
+}
+
+function filterTechs() {
+    let techTables = document.getElementsByClassName("techSchdDiv");
+    let filter = document.getElementById("techSchdFilter").value;
+    console.log("filtering", filter);
+    if (filter == '') {
+        for(let i = 0; i < techTables.length; i++) {
+            techTables[i].hidden = false;
+        }
+        return;
+    }
+    for(let i = 0; i < techTables.length; i++) {
+        if(!techTables[i].getAttribute('id').toLowerCase().includes(filter.toLowerCase())) {
+            techTables[i].hidden = true;
+        }
+    }
+    return;
+}
+
 function makeTechEditTable(techObj) {
     let techTable = document.createElement('div');
+    techTable.classList.add("techSchdDiv");
+    techTable.setAttribute("id", techObj.Name);
     //techTable.innerText = techObj.Name;
     //let techSchedule = techObj.Schedule;
     let tableHTML = `
@@ -193,6 +250,12 @@ function makeTechEditTable(techObj) {
                 ${makeAdminTechSchdRow(techObj, "Thursday")}
                 ${makeAdminTechSchdRow(techObj, "Friday")}
             </tbody>
+            <tfoot>
+                <tr>
+                    <th scope"row" colspan="2">Weekly Hours:</th>
+                    <td id="${techObj.Name.split(" ")[1]}Hours"></td>
+                </tr>
+            </tfoot>
         </table>
         </fieldset>`;
     techTable.innerHTML = tableHTML;
@@ -242,14 +305,14 @@ function makeAdminTechSchdRow(tech, day) {
             ++timeIndex;
         }
         let id = tech.Name.split(" ")[1] + day + timeBlocks[i];
-        html += `<td id="${id}" draggable="true" ondragenter="flipTime('${id}')" onclick="flipTime('${id}')" class="schd${onClock}">\t</td>`;
+        html += `<td id="${id}" draggable="true" ondragenter="flipTime('${tech.Name}','${id}')" onclick="flipTime('${tech.Name}','${id}')" class="schd${onClock}">\t</td>`;
     }
     //console.groupEnd("TimeSwitch vs. TimeBlocks");
     html += `</tr>`
     return html;
 }
 
-function flipTime(tableElementID) {
+function flipTime(techName, tableElementID) {
     let element = document.getElementById(tableElementID);
     if(element.classList.contains("schdtrue")) {
         element.classList.remove("schdtrue");
@@ -257,6 +320,25 @@ function flipTime(tableElementID) {
     } else {
         element.classList.remove("schdfalse");
         element.classList.add("schdtrue");
+    }
+    updateHours(`tech${techName}`,`${techName.split(" ")[1]}Hours`);
+    return;
+}
+
+function updateHours(tableID, tableHoursID) {
+    let table = document.getElementById(tableID);
+    let hoursEntry = document.getElementById(tableHoursID);
+    let onCells = table.getElementsByClassName('schdtrue');
+    //console.log("updateHours", onCells);
+    hoursEntry.innerText = onCells.length * .5;
+    return;
+}
+
+function updateAllTechSchedules() {
+    let tables = document.getElementsByClassName("adminTechTable");
+    for(let i = 0; i < tables.length; i++) {
+        let tableId = tables[i].getAttribute("id");
+        updateTechSchedule(tableId);
     }
     return;
 }

--- a/html-css-js/admin_tools.js
+++ b/html-css-js/admin_tools.js
@@ -153,11 +153,11 @@ function setScheduleEditor() {
     <fieldset className="techSchdOptions">
         <legend> Options </legend>
         <button onclick="updateAllTechSchedules()"> Save All Schedules </button>
-        <button onclick="addBlankTechSchedule()"> Add a Technician </button>
-        <button onclick="setRemoveMode()"> Remove a Technician </button>
-        <button onclick="exportSchd()"> Export Schedules </button>
+        <button onclick="addBlankTechSchedule()"> TODO: Add a Technician </button>
+        <button onclick="setRemoveMode()"> TODO: Remove a Technician </button>
+        <button onclick="exportSchd()"> TODO: Export Schedules </button>
         <div class="techFilterDiv">
-            <label for="techSchdFilter">Filter Technician:</label>
+            <label for="techSchdFilter">Filter Technicians:</label>
             <textarea id="techSchdFilter" placeholder="Name:" onkeyup="filterTechs()"></textarea>
         </div>
     </fieldset>`;
@@ -202,6 +202,9 @@ function addBlankTechSchedules() {
 }
 
 // TODO: Export Schdule
+//  thinking about adding a library to do excel files
+//  if too complex resort to csv.
+//  output may be the literal string inside the tech obj
 function exportSchd() {
     return;
 }
@@ -209,7 +212,7 @@ function exportSchd() {
 function filterTechs() {
     let techTables = document.getElementsByClassName("techSchdDiv");
     let filter = document.getElementById("techSchdFilter").value;
-    console.log("filtering", filter);
+    //console.log("filtering", filter);
     if (filter == '') {
         for(let i = 0; i < techTables.length; i++) {
             techTables[i].hidden = false;

--- a/html-css-js/admin_tools.js
+++ b/html-css-js/admin_tools.js
@@ -155,7 +155,7 @@ function setScheduleEditor() {
         <button onclick="updateAllTechSchedules()"> Save All Schedules </button>
         <button id="addNewTechBttn" onclick="addBlankTechSchedule(0)"> Add a Technician </button>
         <button onclick="setRemoveMode()"> Remove a Technician </button>
-        <button onclick="exportSchd()"> TODO: Export Schedules </button>
+        <button onclick="exportSchd()"> Export Schedules (CSV)</button>
         <div class="techFilterDiv">
             <label for="techSchdFilter">Filter Technicians:</label>
             <textarea id="techSchdFilter" placeholder="Name:" onkeyup="filterTechs()"></textarea>
@@ -208,7 +208,7 @@ function setRemoveMode() {
     // Get current saved Schedule
     let scheduleData = JSON.parse(localStorage.getItem("schedule"));
     let techList = scheduleData["Technicians"];
-    console.log(techList);
+    //console.log(techList);
     // HTML
     let html = `
     <ul id="techSchdRemoveList">`;
@@ -270,11 +270,6 @@ function removeSelectedTechs() {
     return;
 }
 
-// TODO: place a blank tech table at the top of the page.
-//s empty name, unassigned, no time selected on the table.
-// The save button here will need to be a little different
-//  it will need to add the new tech to the array of objects.
-//  the other function updates an existing entry.
 function addBlankTechSchedule(count) {
     //Up Count in onclick
     let newTechBttn = document.getElementById("addNewTechBttn");
@@ -308,7 +303,35 @@ function addBlankTechSchedule(count) {
 //  thinking about adding a library to do excel files
 //  if too complex resort to csv.
 //  output may be the literal string inside the tech obj
+// CSV = comma delimited values
+// MEANING, those strings with ',' to deliminate my shifts in a given day are now a problem
+// while also being gross to look at, the code below also is non-functional because that is 
+// not handled.
 function exportSchd() {
+    // retrieve schd data
+    let scheduleData = JSON.parse(localStorage.getItem("schedule"));
+    let techList = scheduleData["Technicians"];
+    // Define the csv Rows
+    let name_items = ["Name"];
+    let assignment = ["Assignment"];
+    let mon_items = ["Monday"];
+    let tues_items = ["Tuesday"];
+    let wed_items = ["Wednesday"];
+    let thur_items = ["Thursday"];
+    let fri_items = ["Friday"];
+    let tmp = [];
+    for (tech in techList) {
+        name_items.push(techList[tech].Name);
+        assignment.push(techList[tech].Assignment);
+        let schd = techList[tech].Schedule;
+        mon_items.push(schd.Monday.replaceAll(",",";"));
+        tues_items.push(schd.Tuesday.replaceAll(",",";"));
+        wed_items.push(schd.Wednesday.replaceAll(",",";"));
+        thur_items.push(schd.Thursday.replaceAll(",",";"));
+        fri_items.push(schd.Friday.replaceAll(",",";"));
+    }
+    csv = [name_items.join(","),assignment.join(","),mon_items.join(","),wed_items.join(","),thur_items.join(","),fri_items.join(",")].join("\n");
+    downloadCsv(csv);
     return;
 }
 

--- a/html-css-js/admin_tools.js
+++ b/html-css-js/admin_tools.js
@@ -8,11 +8,12 @@ function setAdminBronson() {
     siteheader = document.getElementById("middle");
     adminTabs = document.createElement("div");
     adminTabs.classList.add("tab_row");
-    adminTabs.classList.add("admin_tabs");
+    adminTabs.classList.add("admin_tab");
     adminTabs.innerHTML = `<button id="adminButton" class="toolTab adminTab" onclick="setAdminTools()" type=button><img class="tab_img" src=button2.png></img><span>Admin Tools</span></button>`;
     siteheader.appendChild(adminTabs);
 }
 
+// Set Admin Tool Page
 async function setAdminTools() {
     const menuItems = document.querySelectorAll(".menuItem");
 
@@ -35,16 +36,59 @@ async function setAdminTools() {
     // newCurrent.classList.add("active");
     newCurrent.classList.add("selected");
 
-
     history.pushState("test", "Admin Tools", "/admintools");
 
     let progGuts = document.querySelector('.program_board .program_guts');
 
+    // Build Admin Tools Landing Page
     let at_container = document.createElement("div");
     at_container.classList.add("at_container");
+    // Admin Tool Tab Rows
+    let admin_tab_row = document.createElement("div");
+    admin_tab_row.classList.add("tab_row");
+    admin_tab_row.classList.add("admin_tabs");
+    admin_tab_row.innerHTML = `
+    <button id="at_message" onclick="setMessageEditor()" type="button" class="atTab">
+        <img class="at_tab_img" src="button2.png"/>
+        <span> Message Editor </span>
+    </button>
+    <button id="at_schedule" onclick="setScheduleEditor()" type="button" class="atTab">
+        <img class="at_tab_img" src="button2.png"/>
+        <span> Schedule Editor </span>
+    </button>`;
+    // init admin tool guts
+    let admin_internals = document.createElement("div");
+    admin_internals.setAttribute("id", "admin_internals");
+    admin_internals.innerHTML = `<p> Please Select an Administrative Tool </p>`;
+    // fieldset
+    let at_fieldset = document.createElement('fieldset');
+    at_fieldset.classList.add('at_fieldset');
+    at_fieldset.innerHTML = `<legend> Admin Tools </legend>`;
+    at_fieldset.appendChild(admin_tab_row);
+    at_fieldset.appendChild(admin_internals);
+    at_container.appendChild(at_fieldset);
+
+    let main_container = document.createElement('div');
+    main_container.appendChild(at_container);
+    main_container.classList.add('program_guts');
+    progGuts.replaceWith(main_container);
+    return;
+}
+
+// Set MessageEditor
+// TODO - Check permissions here
+function setMessageEditor() {
+    // remove currently active status, mark tab has active.
+    let current = document.getElementsByClassName("at_selected");
+    if (current.length != 0) {
+        current[0].classList.remove("at_selected");
+    }
+    let newCurrent = document.getElementById("at_message");
+    newCurrent.classList.add("at_selected");
 
     // Update Dashboard Message
     let dashboard_message_editor = document.createElement("div");
+    dashboard_message_editor.setAttribute("id", "admin_internals");
     dashboard_message_editor.classList.add('at_dme'); //dashboard message editor, acronym
     dashboard_message_editor.innerHTML = `
     <fieldset>
@@ -53,14 +97,96 @@ async function setAdminTools() {
         <button onclick="setDashboardMessage()"> Set Message </button>
         <button onclick="clearEditor()"> Clear Editor </button> 
     </fieldset>`;
-
-    at_container.append(dashboard_message_editor);
-
-    let main_container = document.createElement('div');
-    main_container.appendChild(at_container);
-    main_container.classList.add('program_guts');
-    progGuts.replaceWith(main_container);
+    // replace admin_internals
+    let admin_internals = document.getElementById('admin_internals');
+    admin_internals.replaceWith(dashboard_message_editor);
     return;
+}
+
+function setScheduleEditor() {
+    // remove currently active status, mark tab has active.
+    let current = document.getElementsByClassName("at_selected");
+    if (current.length != 0) {
+        current[0].classList.remove("at_selected");
+    }
+    let newCurrent = document.getElementById("at_schedule");
+    newCurrent.classList.add("at_selected");
+    // build tool
+    let schedule_editor = document.createElement('div');
+    schedule_editor.setAttribute("id", "admin_internals");
+    schedule_editor.classList.add('at_se');
+    // get Current Schedule
+    //  Note this will change with the database
+    let scheduleData = JSON.parse(localStorage.getItem("schedule"));
+    if(scheduleData == null) {
+        console.assert("Error: schedule not found in local storage.");
+        return;
+    }
+    for(let i = 0; i < scheduleData.Technicians.length; i++) {
+        console.log(scheduleData.Technicians[i]);
+        schedule_editor.appendChild(makeTechEditTable(scheduleData.Technicians[i]));
+    }
+    // TODO: Make Buttons
+    let buttonFieldset = document.createElement('div');
+    buttonFieldset.innerHTML = `
+    <fieldset>
+        <legend> Buttons </legend>
+        <button> Set Schedule </button>
+        <button> Add Technician </button>
+    </fieldset>`;
+    schedule_editor.appendChild(buttonFieldset);
+    // replace admin_internals
+    let admin_internals = document.getElementById('admin_internals');
+    admin_internals.replaceWith(schedule_editor);
+    return;
+}
+
+// TODO - return a div for each tech given
+function makeTechEditTable(techObj) {
+    let techTable = document.createElement('div');
+    //techTable.innerText = techObj.Name;
+    //let techSchedule = techObj.Schedule;
+    let tableHTML = `
+        <table>
+        <thead>
+        </thead>
+            <tr>
+                <th scope="col">Weekday</th>
+                <th scope="col">7:30AM</th>
+                <th scope="col">8:00AM</th>
+                <th scope="col">8:30AM</th>
+                <th scope="col">9:00AM</th>
+                <th scope="col">9:30AM</th>
+                <th scope="col">10:00AM</th>
+                <th scope="col">10:30AM</th>
+                <th scope="col">11:00AM</th>
+                <th scope="col">11:30AM</th>
+                <th scope="col">12:00PM</th>
+                <th scope="col">12:30PM</th>
+                <th scope="col">1:00PM</th>
+                <th scope="col">1:30PM</th>
+                <th scope="col">2:00PM</th>
+                <th scope="col">2:30PM</th>
+                <th scope="col">3:00PM</th>
+                <th scope="col">3:30PM</th>
+                <th scope="col">4:00PM</th>
+                <th scope="col">4:30PM</th>
+                <th scope="col">5:00PM</th>
+                <th scope="col">5:30PM</th>
+                <th scope="col">6:00PM</th>
+                <th scope="col">6:30PM</th>
+                <th scope="col">7:00PM</th>
+            </tr>
+        <tbody>
+            ${makeTechSchdRow(techObj, "Monday")}
+            ${makeTechSchdRow(techObj, "Tuesday")}
+            ${makeTechSchdRow(techObj, "Wednesday")}
+            ${makeTechSchdRow(techObj, "Thursday")}
+            ${makeTechSchdRow(techObj, "Friday")}
+        </tbody>
+        </table>`;
+    techTable.innerHTML = tableHTML;
+    return techTable;
 }
 
 // Grabs the contents of the text

--- a/html-css-js/admin_tools.js
+++ b/html-css-js/admin_tools.js
@@ -2,6 +2,7 @@
 
 // Note, I think it would be good to put the terminal stuff in here that is currently in index_admin.html but it utilizes JQueury in a way that I am not hundred percent sure of so I will not be doing that just yet because I don't want to break anything.
 
+
 function setAdminBronson() {
     // Add Admin Tool Tab
     siteheader = document.getElementById("middle");

--- a/html-css-js/bronson-manager.js
+++ b/html-css-js/bronson-manager.js
@@ -85,17 +85,25 @@ const Days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", 
 //  change on the backend.
 async function initLocalStorage() {
     // Campus Data (Effectively a clone of the hashmap)
-    let campData = await getCampusData();
-    localStorage.setItem("campData", JSON.stringify(campData));
+    if(localStorage.getItem("campData") == null) {
+        let campData = await getCampusData();
+        localStorage.setItem("campData", JSON.stringify(campData));
+    }
     // Zone Arrays
-    let zoneData = await getZoneData();
-    localStorage.setItem("zoneData", JSON.stringify(zoneData));
+    if (localStorage.getItem("zoneData") == null) {
+        let zoneData = await getZoneData();
+        localStorage.setItem("zoneData", JSON.stringify(zoneData));
+    }
     // Leaderboard
-    let leaderboard = await getLeaderboard();
-    localStorage.setItem("leaderboard", JSON.stringify(leaderboard));
+    if (localStorage.getItem("leaderboard") == null) {
+        let leaderboard = await getLeaderboard();
+        localStorage.setItem("leaderboard", JSON.stringify(leaderboard));
+    }
     // Schedule
-    let schedule = await getSchedule();
-    localStorage.setItem("schedule", schedule);
+    if (localStorage.getItem("schedule") == null) {
+        let schedule = await getSchedule();
+        localStorage.setItem("schedule", schedule);
+    }
     // CheckerboardStorage
     if (sessionStorage.getItem("cb_dash") == null) {
         initCheckerboardStorage();
@@ -275,17 +283,47 @@ function makeTechSchdRow(tech, today) {
 }
 
 function getTechSchdTimeBlocks() {
-    let table_header = document.getElementById("db_tech_times");
-    //console.log(table_header.innerText);
-    let output = table_header.innerText.split("\t");
-    return output.slice(1);
-
+    if(document.title.includes("Dashboard")) {
+        let table_header = document.getElementById("db_tech_times");
+        //console.log(table_header.innerText);
+        let output = table_header.innerText.split("\t");
+        console.log(output.slice(1));
+        return output.slice(1);
+    } else {
+        return [
+            "7:30AM",
+            "8:00AM",
+            "8:30AM",
+            "9:00AM",
+            "9:30AM",
+            "10:00AM",
+            "10:30AM",
+            "11:00AM",
+            "11:30AM",
+            "12:00PM",
+            "12:30PM",
+            "1:00PM",
+            "1:30PM",
+            "2:00PM",
+            "2:30PM",
+            "3:00PM",
+            "3:30PM",
+            "4:00PM",
+            "4:30PM",
+            "5:00PM",
+            "5:30PM",
+            "6:00PM",
+            "6:30PM",
+            "7:00PM"
+        ];
+    }
 }
 
 // TODO : make a bar that indicates the time that spans the height of the tech schedule
 function renderTimeIndicator() {
     return;
 }
+
 // Leaderboard
 function setLeaderWeek() {
     let current = document.getElementsByClassName("leader_selected");

--- a/html-css-js/bronson-manager.js
+++ b/html-css-js/bronson-manager.js
@@ -502,7 +502,7 @@ async function dashCheckerboard() {
         if (object["zones"][item]["rooms"] != 0) {
             let percent = object["zones"][item]["checked"] / object["zones"][item]["rooms"];
             percent = String((100*percent).toFixed(5)).slice(0,5);
-            cb_dashDivHTML += `<li> <label class="cbProgLabel for="${object["zones"][item]["zone"]}_prog">Zone ${object["zones"][item]["zone"]}:  ${percent}%</label><progress id="${object["zones"][item]["zone"]}_prog"value="${percent}" max="100"></progress></li>`;
+            cb_dashDivHTML += `<li> <p>Zone ${object["zones"][item]["zone"]}: </p><label class="cbProgLabel" for="${object["zones"][item]["zone"]}_prog"> ${percent}%</label><progress id="${object["zones"][item]["zone"]}_prog"value="${percent}" max="100"></progress></li>`;
         }
     }
     cb_dashDivHTML += `</ul></fieldset>`;

--- a/html-css-js/bronson-manager.js
+++ b/html-css-js/bronson-manager.js
@@ -76,10 +76,19 @@ async function initLocalStorage() {
     // Leaderboard
     let leaderboard = await getLeaderboard();
     localStorage.setItem("leaderboard", JSON.stringify(leaderboard));
+    // Schedule
+    let schedule = await getSchedule();
+    localStorage.setItem("schedule", schedule);
     // CheckerboardStorage
     if (sessionStorage.getItem("cb_dash") == null) {
         initCheckerboardStorage();
     }
+    // Default Dashboard Selections
+    //  Leaderboard: 7-Days
+    //  Schedule: Current-Day
+    setLeaderWeek();
+    // Get Current Day
+    // Set Schedule
     return;
 }
 
@@ -107,6 +116,17 @@ async function getZoneData() {
 
 async function getLeaderboard() {
     return fetch("leaderboard")
+        .then(response => {
+            if (!response.ok) {
+                throw new Error("HTTP error " + response.status);
+            }
+            return response.json();
+        }
+    );
+}
+
+async function getSchedule() {
+    return fetch("techSchedule")
         .then(response => {
             if (!response.ok) {
                 throw new Error("HTTP error " + response.status);

--- a/html-css-js/bronson-manager.js
+++ b/html-css-js/bronson-manager.js
@@ -231,9 +231,9 @@ function setSchedule(buttonID) {
 function makeTechTableHeader(firstColumn) {
     let times = getTechSchdTimeBlocks();
     let html = `<tr>
-        <th scope="col">${firstColumn}</th>`;
+        <th scope="col" class="schdLeftIndex">${firstColumn}</th>`;
     for(i in times) {
-        html += `<th scope="col">${times[i]}</th>`;
+        html += `<th scope="col" class="timeBlockTable">${times[i]}</th>`;
     }
     html += '</tr>';
     return html;

--- a/html-css-js/bronson-manager.js
+++ b/html-css-js/bronson-manager.js
@@ -195,7 +195,7 @@ function setSchedule(buttonID) {
     // Build the table
     let tbody_HTML = `<tbody>`;
     let today = buttonID.split("Button")[0];
-    console.group(`Technicians`);
+    //console.group(`Technicians`);
     // Sort Technicians by assignment
     const priorityList = ["Zone 1", "Zone 2", "Zone 3", "Zone 4"];
     let zoneTechs = [];
@@ -217,10 +217,10 @@ function setSchedule(buttonID) {
     let techList = zoneTechs.concat(otherTechs);
     // Build Table
     for(let i = 0; i < techList.length; i++) {
-        console.info(techList[i]);
+        //console.info(techList[i]);
         tbody_HTML += makeTechSchdRow(techList[i], today);
     }
-    console.groupEnd(`Technicians`);
+    //console.groupEnd(`Technicians`);
     tbody_HTML += `</tbody>`;
     let tbody = document.createElement('tbody');
     tbody.setAttribute("id", "schd_tbody");
@@ -229,6 +229,17 @@ function setSchedule(buttonID) {
     let table = document.getElementById("schd_tbody");
     table.replaceWith(tbody);
     return;
+}
+
+function makeTechTableHeader(firstColumn) {
+    let times = getTechSchdTimeBlocks();
+    let html = `<tr>
+        <th scope="col">${firstColumn}</th>`;
+    for(i in times) {
+        html += `<th scope="col">${times[i]}</th>`;
+    }
+    html += '</tr>';
+    return html;
 }
 
 function makeTechSchdRow(tech, today) {
@@ -258,7 +269,7 @@ function makeTechSchdRow(tech, today) {
     for(let i = 0; i < timeBlocks.length; i++) {
         //console.info("timeswitch: ", timeSwitches[timeIndex], " Time Block: ", timeBlocks[i]);
         if(timeBlocks[i] == timeSwitches[timeIndex]) {
-            console.log("Hit a timeSwitch");
+            //console.log("Hit a timeSwitch");
             onClock = !onClock;
             ++timeIndex;
             // I want to see when shift ends now
@@ -283,14 +294,7 @@ function makeTechSchdRow(tech, today) {
 }
 
 function getTechSchdTimeBlocks() {
-    if(document.title.includes("Dashboard")) {
-        let table_header = document.getElementById("db_tech_times");
-        //console.log(table_header.innerText);
-        let output = table_header.innerText.split("\t");
-        console.log(output.slice(1));
-        return output.slice(1);
-    } else {
-        return [
+    return [
             "7:30AM",
             "8:00AM",
             "8:30AM",
@@ -316,7 +320,6 @@ function getTechSchdTimeBlocks() {
             "6:30PM",
             "7:00PM"
         ];
-    }
 }
 
 // TODO : make a bar that indicates the time that spans the height of the tech schedule

--- a/html-css-js/bronson-manager.js
+++ b/html-css-js/bronson-manager.js
@@ -59,21 +59,21 @@ These functions are used in both Checkerboard and Jacknet.
 ░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░ ░▒▓█▓▒░  ░▒▓█▓▒░░▒▓█▓▒░ 
 */
 
-class Time {
-    constructor() { this.time = ''; }
+// class Time {
+//     constructor() { this.time = ''; }
 
-    setTime(time) { this.time = time; }
+//     setTime(time) { this.time = time; }
 
-    getTime() { return this.time; }
-}
+//     getTime() { return this.time; }
+// }
 
-class Cookie {
-    constructor() { this.value = "none"; }
+// class Cookie {
+//     constructor() { this.value = "none"; }
 
-    setCookie(id) { this.value = id; }
+//     setCookie(id) { this.value = id; }
 
-    getCookie() { return this.value; }
-}
+//     getCookie() { return this.value; }
+// }
 
 const Days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 // Sets local strage for data used by the various tools
@@ -177,7 +177,7 @@ async function getSchedule() {
 // Dashboard Stuff
 // Schedule
 function setSchedule(buttonID) {
-    console.log(buttonID + " Pressed");
+    //console.log(buttonID + " Pressed");
     let current = document.getElementsByClassName("schedule_selected");
     if (current.length != 0) {
         current[0].classList.remove("schedule_selected");
@@ -195,7 +195,6 @@ function setSchedule(buttonID) {
     // Build the table
     let tbody_HTML = `<tbody>`;
     let today = buttonID.split("Button")[0];
-    //console.group(`Technicians`);
     // Sort Technicians by assignment
     const priorityList = ["Zone 1", "Zone 2", "Zone 3", "Zone 4"];
     let zoneTechs = [];
@@ -217,10 +216,8 @@ function setSchedule(buttonID) {
     let techList = zoneTechs.concat(otherTechs);
     // Build Table
     for(let i = 0; i < techList.length; i++) {
-        //console.info(techList[i]);
         tbody_HTML += makeTechSchdRow(techList[i], today);
     }
-    //console.groupEnd(`Technicians`);
     tbody_HTML += `</tbody>`;
     let tbody = document.createElement('tbody');
     tbody.setAttribute("id", "schd_tbody");
@@ -243,13 +240,12 @@ function makeTechTableHeader(firstColumn) {
 }
 
 function makeTechSchdRow(tech, today) {
-    // console.log(today);
     let html = `
     <tr>
         <th scope="row">${tech.Name}</th>`;
     // get schedule timeblocks
     let timeBlocks = getTechSchdTimeBlocks();
-    //console.log(timeBlocks);
+    timeBlocks.push("7:30PM");
     // get techs schedule for the day
     let timeSwitches = [];
     let shift = tech.Schedule[today].split(",");
@@ -257,19 +253,12 @@ function makeTechSchdRow(tech, today) {
         timeSwitches.push(shift[i].split(' - '))
     }
     timeSwitches = timeSwitches.flat(2);
-    //console.log("Todays Tech Shift: ", shift);
-    //console.log("timeSwitches", timeSwitches);
-    //console.log("timeBlocks", timeBlocks);
     let onClock = false;
     let timeIndex = 0;
     let startShiftIndex, endShiftIndex = 0;
-    //let techState = "OffClock";
-    // Iterate through 25 time blocks;
-    //console.group("TimeSwitch vs. TimeBlocks");
-    for(let i = 0; i < timeBlocks.length; i++) {
-        //console.info("timeswitch: ", timeSwitches[timeIndex], " Time Block: ", timeBlocks[i]);
+    // Iterate through 24 time blocks;
+    for(let i = 0; i < timeBlocks.length-1; i++) {
         if(timeBlocks[i] == timeSwitches[timeIndex]) {
-            //console.log("Hit a timeSwitch");
             onClock = !onClock;
             ++timeIndex;
             // I want to see when shift ends now
@@ -288,38 +277,13 @@ function makeTechSchdRow(tech, today) {
             html += `<td class="schd${onClock}">\t</td>`;
         }
     }
-    //console.groupEnd("TimeSwitch vs. TimeBlocks");
     html += `</tr>`
     return html;
 }
 
+// The headers for scheudles
 function getTechSchdTimeBlocks() {
-    return [
-            "7:30AM",
-            "8:00AM",
-            "8:30AM",
-            "9:00AM",
-            "9:30AM",
-            "10:00AM",
-            "10:30AM",
-            "11:00AM",
-            "11:30AM",
-            "12:00PM",
-            "12:30PM",
-            "1:00PM",
-            "1:30PM",
-            "2:00PM",
-            "2:30PM",
-            "3:00PM",
-            "3:30PM",
-            "4:00PM",
-            "4:30PM",
-            "5:00PM",
-            "5:30PM",
-            "6:00PM",
-            "6:30PM",
-            "7:00PM"
-        ];
+    return ["7:30AM","8:00AM","8:30AM","9:00AM","9:30AM","10:00AM","10:30AM","11:00AM","11:30AM","12:00PM","12:30PM","1:00PM","1:30PM","2:00PM","2:30PM","3:00PM","3:30PM","4:00PM","4:30PM","5:00PM","5:30PM","6:00PM","6:30PM","7:00PM"];
 }
 
 // TODO : make a bar that indicates the time that spans the height of the tech schedule

--- a/html-css-js/checkerboard.js
+++ b/html-css-js/checkerboard.js
@@ -39,21 +39,7 @@ TODO -
       If every room in a building (or zone) is checked, it is an achievement for the tech
       they should get some kinda special message or confetti when this happens.
 */
-class Time {
-    constructor() { this.time = ''; }
 
-    setTime(time) { this.time = time; }
-
-    getTime() { return this.time; }
-}
-
-class Cookie {
-    constructor() { this.value = "none"; }
-
-    setCookie(id) { this.value = id; }
-
-    getCookie() { return this.value; }
-}
 
 // Run Checkerboard
 async function getCheckerboardByBuilding(build_ab) {

--- a/html-css-js/index.html
+++ b/html-css-js/index.html
@@ -145,33 +145,7 @@
           </div>
           <table id="db_schedule_table">
             <thead>
-              <tr id="db_tech_times">
-                <th scope="col">Technician</th>
-                <th scope="col">7:30AM</th>
-                <th scope="col">8:00AM</th>
-                <th scope="col">8:30AM</th>
-                <th scope="col">9:00AM</th>
-                <th scope="col">9:30AM</th>
-                <th scope="col">10:00AM</th>
-                <th scope="col">10:30AM</th>
-                <th scope="col">11:00AM</th>
-                <th scope="col">11:30AM</th>
-                <th scope="col">12:00PM</th>
-                <th scope="col">12:30PM</th>
-                <th scope="col">1:00PM</th>
-                <th scope="col">1:30PM</th>
-                <th scope="col">2:00PM</th>
-                <th scope="col">2:30PM</th>
-                <th scope="col">3:00PM</th>
-                <th scope="col">3:30PM</th>
-                <th scope="col">4:00PM</th>
-                <th scope="col">4:30PM</th>
-                <th scope="col">5:00PM</th>
-                <th scope="col">5:30PM</th>
-                <th scope="col">6:00PM</th>
-                <th scope="col">6:30PM</th>
-                <th scope="col">7:00PM</th>
-              </tr>
+              ${makeTechTableHeader("Technician")}
             </thead>
             <tbody id="schd_tbody">
             </tbody>

--- a/html-css-js/index.html
+++ b/html-css-js/index.html
@@ -19,8 +19,6 @@
   <script src="camcode.js" type="text/javascript" charset="utf-8"></script>
   <script src="cc-altmode.js" type="text/javascript" charset="utf-8"></script>
   <script src="jacknet.js" type="text/javascript" charset="utf-8"></script>
-  <!-- <script src="signing.js" type="text/javascript" charset="utf-8"></script> -->
-  <!-- <script src="wiki.js" type="text/javascript" charset="utf-8"></script> -->
   <!-- <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> -->
   <script>
     window.addEventListener("popstate", () => {
@@ -114,6 +112,8 @@
       `;
 
       // Dashboard Schedule
+      // note 25 time segments, 12.5 hours / 30min
+      //       1 column for technician name
       let schedule = document.createElement("div");
       schedule.classList.add("db_schedule");
       schedule.innerHTML = `
@@ -134,7 +134,7 @@
               <img class="leader_tab_img" src="button2.png"/>
               <span>Wednesday</span>
             </button>
-            <button id="ThusdayButton" onclick="setSchedule('ThursdayButton')" type="button" class="leaderTab">
+            <button id="ThursdayButton" onclick="setSchedule('ThursdayButton')" type="button" class="leaderTab">
               <img class="leader_tab_img" src="button2.png"/>
               <span>Thursday</span>
             </button>
@@ -144,9 +144,42 @@
             </button>
           </div>
           <table id="db_schedule_table">
+            <thead>
+              <tr id="db_tech_times">
+                <th scope="col">Technician</th>
+                <th scope="col">7:30AM</th>
+                <th scope="col">8:00AM</th>
+                <th scope="col">8:30AM</th>
+                <th scope="col">9:00AM</th>
+                <th scope="col">9:30AM</th>
+                <th scope="col">10:00AM</th>
+                <th scope="col">10:30AM</th>
+                <th scope="col">11:00AM</th>
+                <th scope="col">11:30AM</th>
+                <th scope="col">12:00PM</th>
+                <th scope="col">12:30PM</th>
+                <th scope="col">1:00PM</th>
+                <th scope="col">1:30PM</th>
+                <th scope="col">2:00PM</th>
+                <th scope="col">2:30PM</th>
+                <th scope="col">3:00PM</th>
+                <th scope="col">3:30PM</th>
+                <th scope="col">4:00PM</th>
+                <th scope="col">4:30PM</th>
+                <th scope="col">5:00PM</th>
+                <th scope="col">5:30PM</th>
+                <th scope="col">6:00PM</th>
+                <th scope="col">6:30PM</th>
+                <th scope="col">7:00PM</th>
+              </tr>
+            </thead>
+            <tbody id="schd_tbody">
+            </tbody>
           </table>
         </fieldset>`;
-
+      // Once initStorageRuns and grabs the schedule data,
+      // we will update this table and append <tbody>
+      //  - maybe stats on hours in a <tfoot>, unsure.
       db_container.appendChild(consoleOutput);
       db_container.appendChild(leaderboard);
       db_container.appendChild(schedule);
@@ -165,78 +198,6 @@
       // Init sessionStorage
       initLocalStorage();
       return;
-    }
-
-    function setSchedule(buttonID) {
-      console.log(buttonID + " Pressed");
-      return;
-    }
-
-    // Bad Methodology Here
-    // async function buildScheduleTableHTML(tabID) {
-    //   // let scheduleData = JSON.parse(document.getElementById('techData'));
-    //   let scheduleData = JSON.parse(localStorage.getItem("schedule"));
-    //   if(scheduleData == null) {
-    //     let schedule = await getSchedule();
-    //     localStorage.setItem("schedule", JSON.stringify(schedule));
-    //     scheduleData = JSON.parse(schedule);
-    //   }
-    //   console.log(scheduleData);
-    //   return;
-    // }
-
-    function setLeaderWeek() {
-      let current = document.getElementsByClassName("leader_selected");
-      if (current.length != 0) {
-          current[0].classList.remove("leader_selected");
-      }
-      let newCurrent = document.getElementById("WeekButton");
-      newCurrent.classList.add("leader_selected");
-
-      let weekLeader = JSON.parse(localStorage.getItem("leaderboard"))["7days"];
-      let leaderString = "";
-      for (let i=0; i<weekLeader.length; i++) {
-        leaderString += `${weekLeader[i].Name}: ${weekLeader[i].Count}\n`;
-      }
-
-      let leaderboard = document.getElementById("leaderboard");
-      leaderboard.innerHTML = leaderString;
-    }
-
-    function setLeaderMonth() {
-      let current = document.getElementsByClassName("leader_selected");
-      if (current.length != 0) {
-          current[0].classList.remove("leader_selected");
-      }
-      let newCurrent = document.getElementById("MonthButton");
-      newCurrent.classList.add("leader_selected");
-
-      let weekLeader = JSON.parse(localStorage.getItem("leaderboard"))["30days"];
-      let leaderString = "";
-      for (let i=0; i<weekLeader.length; i++) {
-        leaderString += `${weekLeader[i].Name}: ${weekLeader[i].Count}\n`;
-      }
-
-      let leaderboard = document.getElementById("leaderboard");
-      leaderboard.innerHTML = leaderString;
-    }
-
-    function setLeaderSemester() {
-      let current = document.getElementsByClassName("leader_selected");
-      if (current.length != 0) {
-          current[0].classList.remove("leader_selected");
-      }
-      let newCurrent = document.getElementById("SemesterButton");
-      newCurrent.classList.add("leader_selected");
-
-      let weekLeader = JSON.parse(localStorage.getItem("leaderboard"))["90days"];
-      let leaderString = "";
-      for (let i=0; i<weekLeader.length; i++) {
-        leaderString += `${weekLeader[i].Name}: ${weekLeader[i].Count}\n`;
-      }
-
-      let leaderboard = document.getElementById("leaderboard");
-      leaderboard.innerHTML = leaderString;
     }
 
     // Bug Report form

--- a/html-css-js/index.html
+++ b/html-css-js/index.html
@@ -19,7 +19,6 @@
   <script src="camcode.js" type="text/javascript" charset="utf-8"></script>
   <script src="cc-altmode.js" type="text/javascript" charset="utf-8"></script>
   <script src="jacknet.js" type="text/javascript" charset="utf-8"></script>
-
   <!-- <script src="signing.js" type="text/javascript" charset="utf-8"></script> -->
   <!-- <script src="wiki.js" type="text/javascript" charset="utf-8"></script> -->
   <!-- <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> -->
@@ -37,7 +36,7 @@
         setDashboard();
       }
     },
-    false,
+      false,
     );
 
     function toggleMenu() {
@@ -93,7 +92,7 @@
                 </textarea>
             </fieldset>`;
         });
-  
+      // Dashboard Leaderboard
       let leaderboard = document.createElement("div");
       leaderboard.classList.add("db_leader");
         leaderboard.innerHTML = `
@@ -114,8 +113,43 @@
         </fieldset>
       `;
 
+      // Dashboard Schedule
+      let schedule = document.createElement("div");
+      schedule.classList.add("db_schedule");
+      schedule.innerHTML = `
+        <fieldset>
+          <legend>
+            Schedule
+          </legend>
+          <div class="tab_row schedule">
+            <button id="MondayButton" onclick="setSchedule('MondayButton')" type="button" class="leaderTab">
+              <img class="leader_tab_img" src="button2.png"/>
+              <span>Monday</span>
+            </button>
+            <button id="TuesdayButton" onclick="setSchedule('TuesdayButton')" type="button" class="leaderTab">
+              <img class="leader_tab_img" src="button2.png"/>
+              <span>Tuesday</span>
+            </button>
+            <button id="WednesdayButton" onclick="setSchedule('WednesdayButton')" type="button" class="leaderTab">
+              <img class="leader_tab_img" src="button2.png"/>
+              <span>Wednesday</span>
+            </button>
+            <button id="ThusdayButton" onclick="setSchedule('ThursdayButton')" type="button" class="leaderTab">
+              <img class="leader_tab_img" src="button2.png"/>
+              <span>Thursday</span>
+            </button>
+            <button id="FridayButton" onclick="setSchedule('FridayButton')" type="button" class="leaderTab">
+              <img class="leader_tab_img" src="button2.png"/>
+              <span>Friday</span>
+            </button>
+          </div>
+          <table id="db_schedule_table">
+          </table>
+        </fieldset>`;
+
       db_container.appendChild(consoleOutput);
       db_container.appendChild(leaderboard);
+      db_container.appendChild(schedule);
 
       // Check for client-side cached response
       if(sessionStorage.getItem("cb_body") != null) {
@@ -132,6 +166,24 @@
       initLocalStorage();
       return;
     }
+
+    function setSchedule(buttonID) {
+      console.log(buttonID + " Pressed");
+      return;
+    }
+
+    // Bad Methodology Here
+    // async function buildScheduleTableHTML(tabID) {
+    //   // let scheduleData = JSON.parse(document.getElementById('techData'));
+    //   let scheduleData = JSON.parse(localStorage.getItem("schedule"));
+    //   if(scheduleData == null) {
+    //     let schedule = await getSchedule();
+    //     localStorage.setItem("schedule", JSON.stringify(schedule));
+    //     scheduleData = JSON.parse(schedule);
+    //   }
+    //   console.log(scheduleData);
+    //   return;
+    // }
 
     function setLeaderWeek() {
       let current = document.getElementsByClassName("leader_selected");

--- a/html-css-js/index_admin.html
+++ b/html-css-js/index_admin.html
@@ -9,7 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
     <script src="admin_tools.js"></script>
-    <script src="bronson-manager.js"></script>
+    <!-- <script src="bronson-manager.js"></script> -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css"/>
     <script type="text/javascript">
       // $.get("index.html", await function(data){

--- a/html-css-js/index_admin.html
+++ b/html-css-js/index_admin.html
@@ -10,10 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
     <script src="admin_tools.js"></script>
     <script src="bronson-manager.js"></script>
-    <!-- <script src="camcode.js" type="text/javascript" charset="utf-8"></script>
-    <script src="cc-altmode.js" type="text/javascript" charset="utf-8"></script>
-    <script src="jacknet.js" type="text/javascript" charset="utf-8"></script> -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css"/>    
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css"/>
     <script type="text/javascript">
       // $.get("index.html", await function(data){
       //   $("#prog_placeholder").replaceWith(data);

--- a/html-css-js/jacknet.js
+++ b/html-css-js/jacknet.js
@@ -348,7 +348,7 @@ async function pingpong(devices, building) {
 //   [
 //     [[ROOM1-DEV1-1, ROOM1-DEV1-2],[ROOM1-DEV2-1],[]],
 //     [[ROOM2-DEV1-1, ROOM2-DEV1-2],[ROOM2-DEV2-1],[ROOM2-DEV3-1]],
-//     [[...],[...]]
+//     [[...],[...],[...]]
 //   ],
 //   [
 //      [[IP-ADDRS],[...],[...]],
@@ -385,6 +385,7 @@ function formatPingPong(PingPongJSON, devices) {
     }
     // output
     let new_PR = [out_hn, out_ip];
+    console.log(new_PR);
     return new_PR;
 }
 

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -1,3 +1,9 @@
+/*
+page.css
+
+This file is a nightmare
+*/
+
 /* Global Definitions */
 body {
     background-color: rgb(50, 50, 50);
@@ -529,10 +535,6 @@ button:-webkit-details-marker {
     width: 100%;
 }
 
-.db_schedule {
-    grid-column: 2/8;
-    grid-row:2;
-}
 
 /* .leaderTab {
     width:25%;
@@ -602,14 +604,14 @@ button:-webkit-details-marker {
     /* border: none; */
 }
 
-.leaderTab.leader_selected {
+.leaderTab.leader_selected, .leaderTab.schedule_selected {
     transform: matrix(1, 0, 0, .7, 0, 3.5);
     transition-duration: 0.1s;
     filter: hue-rotate(-60deg);
     /* margin: -12px -6px; */
 }
 
-.leaderTab.leader_selected span {
+.leaderTab.leader_selected span, .leaderTab.schedule_selected span {
     transform: scaleY(1.6);
     top: 0px;
     bottom: 5px;
@@ -638,8 +640,45 @@ button:-webkit-details-marker {
 .semesterTab {
     grid-column: auto;
     z-index: 2;
-    
 }
+
+/* Schedule Stuff */
+.db_schedule {
+    grid-column: 2/8;
+    grid-row:2;
+}
+
+.schedule {
+    transform: translate(90px, 1px);
+}
+
+#db_schedule_table {
+    font-weight:100;
+    font-size:x-small;
+    font-family:'Courier New', Courier, monospace;
+    border: 1px inset rgb(216, 192, 104);
+    color:rgb(194, 181, 124);
+    border-radius: 4px;
+    padding-bottom: 5px;
+}
+
+#db_schedule_table thead {
+    /* border: 2px outset gold; */
+}
+
+#db_schedule_table th {
+    border: 1px outset rgb(220, 183, 96);
+    font-size: xx-small;
+}
+
+.schdfalse {
+    border:#24292E solid 2px;
+}
+
+.schdtrue {
+    background-color: rgb(49, 125, 64);
+}
+
 
 /* .leaderTab.leader_selected {
     transform: translateY(4px);

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -629,6 +629,14 @@ button:-webkit-details-marker {
     transform: translate(90px, 1px);
 }
 
+.timeBlockTable {
+    text-align:left;
+    vertical-align: bottom;
+    font-size: xx-small;
+    border: none;
+    border-left: 1px inset rgb(216,192,104);
+}
+
 #db_schedule_table {
     font-weight:100;
     font-size:x-small;
@@ -1336,85 +1344,6 @@ ol li::marker {
     opacity: 40%;
 }
 
-/* Wiki Defifnitions 
- __          ___ _    _ 
- \ \        / (_) |  (_)
-  \ \  /\  / / _| | ___ 
-   \ \/  \/ / | | |/ / |
-    \  /\  /  | |   <| |
-     \/  \/   |_|_|\_\_|
-*/
-textarea:invalid {
-    border: 2px dashed red;
-  }
-  
-textarea:valid {
-    border: 2px solid lime;
-}
-
-/* Container for input and preview */
-.w_editor{
-    position: relative;
-    background-color: rgb(50, 50, 50);
-    display: grid;
-    grid-template-columns: repeat(11,1fr);
-    gap: 10px;
-    grid-auto-rows: minmax(20px, auto);
-}
-
-.w_input {
-    background-color: rgb(36, 35, 35);
-    float: left;
-    display: block;
-    grid-column: 3 / 7;
-    grid-row: 2 / 5;
-}
-
-.inputWindow {
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    color:rgb(205, 205, 205);
-    background-color: rgb(50, 50, 50)
-}
-
-.w_preview {
-    background-color: rgb(50, 50, 50);
-    color: rgb(236, 200, 101);
-    float: right;
-    display: block;
-    grid-column: 7 / 11;
-    grid-row: 2 / 5;
-    border:4px outset rgb(142, 136, 117);
-    /* box-shadow: 5px 10px 10px; */
-}
-
-.w_optionMenu {
-    display: block;
-    grid-column: 3 / 11;
-    border:4px outset rgb(89, 85, 73);
-}
-
-.w_toc {
-    background-color: rgb(173, 169, 110);
-    display: block;
-    border:4px outset rgb(89, 85, 73);
-    grid-column: 2;
-    grid-row: 1 / 5;
-}
-
-.w_fieldset {
-    border:4px inset rgb(102, 98, 84);
-    background-color: rgb(50, 50, 50);
-    color: rgb(236, 200, 101);
-}
-
-.w_legend {
-    border:2px outset rgb(102, 98, 84);
-    background-color: rgb(50, 50, 50);
-
-}
-
 /* Terminal definitions
 
 */
@@ -1469,6 +1398,65 @@ textarea:valid {
     border:2px inset rgb(122,113,45);
     padding-bottom: 5px;
     margin-bottom:5px;
+}
+
+/* Admin Tools -- Schedule Editor */
+.techFieldset {
+    padding: 3px 3px 3px 3px;
+    display: flex;
+}
+
+
+.techFieldset label {
+    font-size:small;
+}
+
+.techFieldset select {
+    width:100%;
+}
+
+.techFieldset textarea {
+    height:17%;
+    width: 100%;
+    margin: 0px;
+    float: right;
+}
+
+.schdTechFields {
+    width: 12%;
+}
+
+.techAssignmentSelectDiv {
+    padding: 1px 1px 1px 1px;
+    display: flex;
+    width: 100%;
+}
+
+.techSchdNameDiv {
+    padding: 1px 1px 1px 1px;
+    display: flex;
+    width: 48%;
+}
+
+.adminTechTable {
+    font-weight:100;
+    font-size:small;
+    font-family:'Courier New', Courier, monospace;
+    border: 1px inset rgb(216, 192, 104);
+    color:rgb(194, 181, 124);
+    border-radius: 4px;
+    padding-bottom: 5px;
+    width:87%;
+    height:165px;
+}
+
+.adminTechTable .schdLeftIndex {
+    border: 1px outset rgb(220, 183, 96);
+    font-size: x-small;
+}
+
+.adminTechTable th {
+    width: 50px;
 }
 
 .admin_tabs {

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -22,13 +22,13 @@ ul {
     list-style-type: none;
 }
 
-p {
+/* p {
     color: rgb(236, 200, 101);
     text-align: center;
-    /* font-family:'Courier New', Courier, monospace; */
+
     font-family: 'Lucida Sans', sans-serif;
     font-size: medium;
-}
+} */
 
 textarea {
     margin: auto;
@@ -1501,6 +1501,16 @@ ol li::marker {
     transform: scale(1.1);
     box-shadow:#302f35 2px 2px 2px 2px;
 }
+
+.admin_internals li {
+    background-color:#a5a29c;
+    border: 2px black;
+}
+.setToRemove {
+    background-color:red;
+}
+
+/* TABS */
 
 .admin_tabs {
     margin: -9px 0px 26px 0px;

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -22,6 +22,14 @@ ul {
     list-style-type: none;
 }
 
+p {
+    color: rgb(236, 200, 101);
+    text-align: center;
+    /* font-family:'Courier New', Courier, monospace; */
+    font-family: 'Lucida Sans', sans-serif;
+    font-size: medium;
+}
+
 textarea {
     margin: auto;
     width: 100%;
@@ -499,7 +507,7 @@ button:-webkit-details-marker {
 }
 
 .db_console {
-    grid-column: 2 / 8;
+    grid-column: 4 / 8;
     grid-row: 1 / 2;
     /* width: 59%; */
 }
@@ -511,7 +519,19 @@ button:-webkit-details-marker {
     width: 60%; */
     width: 100%;
 }
+.db_schedule {
+    grid-column: 2/10;
+    grid-row:2;
+}
 
+.cb_dash {
+    grid-column:2/4;
+    grid-row:1/2;
+}
+
+.cb_dash fieldset {
+    height: 95%;
+}
 
 /* .leaderTab {
     width:25%;
@@ -620,13 +640,9 @@ button:-webkit-details-marker {
 }
 
 /* Schedule Stuff */
-.db_schedule {
-    grid-column: 2/8;
-    grid-row:2;
-}
 
 .schedule {
-    transform: translate(90px, 1px);
+    transform: translate(90px, -2px);
 }
 
 .timeBlockTable {
@@ -645,14 +661,21 @@ button:-webkit-details-marker {
     color:rgb(194, 181, 124);
     border-radius: 4px;
     padding-bottom: 5px;
+    width:100%;
 }
 
-#db_schedule_table thead {
+#db_schedule_table .timeBlockTable {
     /* border: 2px outset gold; */
+    width: 3%;
+    text-align: left;
+    vertical-align:bottom;
+    border: none;
+    border-left: 1px inset rgb(216, 192, 104);
 }
 
 #db_schedule_table th {
     border: 1px outset rgb(220, 183, 96);
+    width:7%;
     font-size: xx-small;
 }
 
@@ -671,10 +694,7 @@ button:-webkit-details-marker {
     border-bottom: 26px solid #7c1919;
 } */
 
-.cb_dash {
-    grid-column:8/10;
-    grid-row:2;
-}
+
 .cb_dashZones {
     margin: 0px;
     padding: 0px;
@@ -1072,6 +1092,7 @@ span.psw {
     font-family: 'Courier New', Courier, monospace;
     margin:0px 0px 4px 0px;
     font-weight: bold;
+    text-align: left;
 }
 
 .cbTopperBuildingStatus {
@@ -1403,15 +1424,18 @@ ol li::marker {
 /* Admin Tools -- Schedule Editor */
 /* Top Options */
 #techSchdFilter {
-    width:20%;
+    width:70%;
     height:25px;
     float:right;
 }
 
 .techFilterDiv {
-    width: 50%;
+    width: 25%;
     height: 30px;
     float:right;
+}
+.techFilterDiv label {
+    font-size:small;
 }
 
 /* Tech Tables */
@@ -1471,6 +1495,11 @@ ol li::marker {
 
 .adminTechTable th {
     width: 50px;
+}
+
+.adminTechTable .schdtrue:hover {
+    transform: scale(1.1);
+    box-shadow:#302f35 2px 2px 2px 2px;
 }
 
 .admin_tabs {

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -1401,11 +1401,25 @@ ol li::marker {
 }
 
 /* Admin Tools -- Schedule Editor */
+/* Top Options */
+#techSchdFilter {
+    width:20%;
+    height:25px;
+    float:right;
+}
+
+.techFilterDiv {
+    width: 50%;
+    height: 30px;
+    float:right;
+}
+
+/* Tech Tables */
+
 .techFieldset {
     padding: 3px 3px 3px 3px;
     display: flex;
 }
-
 
 .techFieldset label {
     font-size:small;

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -1,7 +1,8 @@
 /*
 page.css
 
-This file is a nightmare
+This file is a nightmare to navigate.
+need to consolidate things and reuse tags
 */
 
 /* Global Definitions */
@@ -22,13 +23,13 @@ ul {
     list-style-type: none;
 }
 
-/* p {
+p {
     color: rgb(236, 200, 101);
     text-align: center;
 
     font-family: 'Lucida Sans', sans-serif;
     font-size: medium;
-} */
+}
 
 textarea {
     margin: auto;
@@ -304,7 +305,7 @@ button:-webkit-details-marker {
 }
 
 .toolTab.selected {
-    transform: matrix(1, 0, 0, .7, 0, 3.5);
+    transform: matrix(1, 0, 0, .7, 0, 4);
     transition-duration: 0.1s;
     filter: hue-rotate(-60deg);
     /* margin: -12px -6px; */
@@ -524,6 +525,11 @@ button:-webkit-details-marker {
     grid-row:2;
 }
 
+.db_schedule fieldset {
+    min-width: 0px;
+    overflow-x: scroll;
+}
+
 .cb_dash {
     grid-column:2/4;
     grid-row:1/2;
@@ -569,7 +575,7 @@ button:-webkit-details-marker {
     font-family: "Racing Sans One", sans-serif;
     font-size: 14px;
     text-align: center;
-    width:80px;
+    width:72px;
     transition-duration: .2s;
 }
 
@@ -598,14 +604,12 @@ button:-webkit-details-marker {
     filter: hue-rotate(35deg);
     padding-top:0px;
     box-shadow: none;
-    /* border: none; */
 }
 
 .leaderTab.leader_selected, .leaderTab.schedule_selected {
-    transform: matrix(1, 0, 0, .7, 0, 3.5);
+    transform: matrix(1, 0, 0, .7, 0, 4);
     transition-duration: 0.1s;
     filter: hue-rotate(-60deg);
-    /* margin: -12px -6px; */
 }
 
 .leaderTab.leader_selected span, .leaderTab.schedule_selected span {
@@ -616,11 +620,10 @@ button:-webkit-details-marker {
     padding: 0px 4px 20px 4px;
     margin: 2px 0px 8px 0px;
     filter: hue-rotate(20deg);
-    /* width:67%; */
 }
 
 .leader_tab_img {
-    width:98px;
+    width:90px;
     height:30px;
 }
 
@@ -642,7 +645,8 @@ button:-webkit-details-marker {
 /* Schedule Stuff */
 
 .schedule {
-    transform: translate(90px, -2px);
+    transform: translate(90px, 5px);
+    width: 500px;
 }
 
 .timeBlockTable {
@@ -660,8 +664,10 @@ button:-webkit-details-marker {
     border: 1px inset rgb(216, 192, 104);
     color:rgb(194, 181, 124);
     border-radius: 4px;
+    margin-top:11px;
     padding-bottom: 5px;
     width:100%;
+    overflow-x: scroll;
 }
 
 #db_schedule_table .timeBlockTable {
@@ -698,6 +704,18 @@ button:-webkit-details-marker {
 .cb_dashZones {
     margin: 0px;
     padding: 0px;
+}
+
+.cb_dashZones p {
+    font-family: "Racing Sans One", sans-serif;
+    text-align: left;
+    font-size: 18pt;
+    padding: 0px 0px 0px 30px;
+    margin: 0px 0px 0px 0px;
+}
+
+.cb_dashZones progress {
+    width: 75%;
 }
 
 input[type=text], input[type=password] {
@@ -800,6 +818,21 @@ span.psw {
     }
     .cancelbtn {
         width: 100%;
+    }
+}
+
+@media (max-width: 1000px) {
+    .db_leader {
+        grid-column: 8/11;
+    }
+    .db_schedule {
+        grid-column: 1/-1;
+    }
+    .cb_dash {
+        grid-column: 1/4;
+    }
+    .cb_dash progress {
+        width: 50%;
     }
 }
 
@@ -969,6 +1002,7 @@ span.psw {
     text-align: center;
     margin:0rem;
     /* margin-right: .5rem; */
+    font-family:serif;
 }
 
 .visRoomDevice {

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -529,6 +529,11 @@ button:-webkit-details-marker {
     width: 100%;
 }
 
+.db_schedule {
+    grid-column: 2/8;
+    grid-row:2;
+}
+
 /* .leaderTab {
     width:25%;
 } */
@@ -565,7 +570,7 @@ button:-webkit-details-marker {
     font-family: "Racing Sans One", sans-serif;
     font-size: 14px;
     text-align: center;
-    width:62px;
+    width:80px;
     transition-duration: .2s;
 }
 
@@ -616,7 +621,7 @@ button:-webkit-details-marker {
 }
 
 .leader_tab_img {
-    width:80px;
+    width:98px;
     height:30px;
 }
 

--- a/html-css-js/page.css
+++ b/html-css-js/page.css
@@ -470,29 +470,6 @@ button:-webkit-details-marker {
     margin: 4px;
     margin-left: 136px;
 }
-/* Admin Tools */
-
-.admin_tabs {
-    float:right;
-    transform: matrix(1,0,0,1,-5,2);
-}
-
-.at_container {
-    background-color: rgb(50,50,50);
-    display: grid;
-    grid-template-columns: repeat(10,1fr);
-    grid-auto-rows:minmax(20px, auto);
-}
-
-.at_dme {
-    grid-column: 2/6;
-}
-
-#dme_editor {
-    border:2px inset rgb(122,113,45);
-    padding-bottom: 5px;
-    margin-bottom:5px;
-}
 
 /*
   _____            _     _             _ 
@@ -1459,4 +1436,125 @@ textarea:valid {
     background-color: rgb(50, 50, 50);
     color: rgb(236, 200, 101);
     border-top: 2px inset rgb(236, 200, 101);
+}
+
+/* Admin Tools */
+.admin_tab {
+    float:right;
+    transform: matrix(1,0,0,1,-5,2);
+}
+
+.at_container {
+    background-color: rgb(50,50,50);
+    display: grid;
+    grid-template-columns: repeat(10,1fr);
+    grid-auto-rows:minmax(20px, auto);
+}
+
+.at_fieldset {
+    grid-column: 2/10;
+}
+
+#admin_internals {
+    border: 1px inset rgb(236,200,101);
+    border-radius:15px;
+    padding: 5px 0px 0px 0px;
+}
+
+.at_dme {
+    grid-column: 2/6;
+}
+
+#dme_editor {
+    border:2px inset rgb(122,113,45);
+    padding-bottom: 5px;
+    margin-bottom:5px;
+}
+
+.admin_tabs {
+    margin: -9px 0px 26px 0px;
+    padding: 0px 0px 1px 13px;
+    /* width: 350px; */
+    display: flex;
+}
+
+.atTab {
+    margin: -12px -6px;
+    opacity: 100%;
+    grid-row: 1;
+    text-align: center;
+    border: none;
+    background-color: transparent;
+    box-sizing: content-box;
+    box-shadow: none;
+}
+
+.atTab span { 
+    position: absolute;
+    top: 3px;
+    left: 13px;
+    bottom: 0px;
+    color: rgb(180, 142, 79);
+    background: rgb(88,79,51);
+    border: rgb(135,62,9) solid 2px;
+    border-bottom: none;
+    border-radius: 10px;
+    padding: 0px 0px 0px 0px;
+    margin: 2px 0px 10px 0px;
+    font-family: "Racing Sans One", sans-serif;
+    font-size: 14px;
+    text-align: center;
+    width:107px;
+    transition-duration: .2s;
+}
+
+.atTab:hover{
+    text-decoration: none;
+    transition-duration: 0.1s;
+    transform: matrix(1,0,0,1.1,0,-1.5);
+    background: transparent;
+    filter: hue-rotate(10deg);
+}
+
+.atTab:active span {
+    transform: matrix(1,0,0,1.5,0,-30);
+    top: 4px;
+    bottom: -3px;
+    left: 14px;
+    padding: 0px 0px 0px 0px;
+    transition-duration: .1s;
+    border: none;
+}
+
+.atTab:active {
+    background: transparent;
+    transform: matrix(1,0,0,.5,0,6);
+    transition-duration:.1s;
+    filter: hue-rotate(35deg);
+    padding-top:0px;
+    box-shadow: none;
+    /* border: none; */
+}
+
+.atTab.at_selected {
+    transform: matrix(1, 0, 0, .7, 0, 3.5);
+    transition-duration: 0.1s;
+    filter: hue-rotate(-60deg);
+    /* margin: -12px -6px; */
+}
+
+.atTab.at_selected span {
+    transform: scaleY(1.6);
+    top: 0px;
+    bottom: 5px;
+    left:8px;
+    padding: 0px 5.5px 20px 5.5px;
+    margin: 2px 0px 8px 0px;
+    filter: hue-rotate(20deg);
+    /* width:67%; */
+}
+
+.at_tab_img {
+    width:130px;
+    height:30px;
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -47,7 +47,7 @@ use server_lib::{
     Room, Building, 
     CFMRequest, CFMRoomRequest, CFMRequestFile, 
     jp::{ ping_this, },
-    BLDG_JSON, ROOM_CSV, CAMPUS_CSV, KEYS, 
+    TSCH_JSON, BLDG_JSON, ROOM_CSV, CAMPUS_CSV, KEYS, 
     CFM_DIR, WIKI_DIR, 
     Request, Response, STATUS_200, STATUS_303, STATUS_404,
 };
@@ -378,11 +378,13 @@ async fn handle_connection(
             res.status(STATUS_200);
             res.send_file("assets/button2.png");
         },
-        "GET /button2red.png HTTP/1.1"        => {
-            res.status(STATUS_200);
-            res.send_file("assets/button2red.png");
-        },
         // Data Requests
+        "GET /techSchedule HTTP/1.1"  => {
+            let contents = get_tech_schedules();
+            res.status(STATUS_200);
+            //res.send_file("data/techSchedule.json");
+            res.send_contents(contents);
+        },
         "GET /campusData HTTP/1.1"         => {
             let contents = json!(&buildings).to_string().into();
             res.status(STATUS_200);
@@ -801,6 +803,13 @@ fn get_zone_data(buildings: HashMap<String, Building>) -> Vec<u8> {
             ]
         });
     return json_return.to_string().into();
+}
+
+fn get_tech_schedules() -> Vec<u8> {
+    let tsch_file: String = read_to_string(TSCH_JSON).expect("Error");
+    //let schedules: String = serde_json::from_str(tsch_file.as_str()).expect("Error");
+    let contents: Vec<u8> = json!(tsch_file).to_string().into();
+    return contents;
 }
 
 /*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,6 +474,7 @@ pub struct GeneralRequest {
 	pub buffer: String
 }
 
+pub static TSCH_JSON : &str = concat!(env!("CARGO_MANIFEST_DIR"), "/data/techSchedule.json");
 pub static BLDG_JSON : &str = concat!(env!("CARGO_MANIFEST_DIR"), "/data/buildings.json");
 pub static CAMPUS_STR: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/data/campus.json"));
 pub static CFM_DIR   : &str = concat!(env!("CARGO_MANIFEST_DIR"), "/CFM_Code");


### PR DESCRIPTION
Dashboard now features a schedule tool for all our technicians. This comes with a couple of changes. Overhauled the Admin Tools page and added a tab to manage the schedule including adding and removing techs, changing assignment and hours. Some of this will be reworked when integrated with the database which will be happening this week as well. The dashboard schedule widget displays all weekdays and will default to whatever the current day is onpage load. 

On top of this, some graphical tweaks to better support mobile browser window sizes.